### PR TITLE
Prevent overwriting of test executable

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,3 +25,6 @@ tracing = { default-features = false, version = "0.1.40" }
 
 [dev-dependencies]
 itertools = "0.12"
+
+[build-dependencies]
+clap = { version = "4.5.1", features = ["std", "derive", "env", "help"], default-features = false }


### PR DESCRIPTION
If `OUT_DIR` is set during test execution like we expect we would have overwritten the test executable with itself. Previously this seemed to have worked but with versions around 1.77.1 starts to mutilate the destination file. Prevent such overwriting.